### PR TITLE
Add workaround note for Node hash error

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 
 Builds the app and publish it at the `homepage` URL given in the package.json.
 
+### Troubleshooting
+
+If you get the following error:
+
+```
+Error: error:0308010C:digital envelope routines::unsupported
+    at new Hash (node:internal/crypto/hash:71:19)
+    at Object.createHash (node:crypto:133:10)
+...
+```
+
+then set `NODE_OPTIONS=--openssl-legacy-provider` first. An example for Windows is:
+
+```bat
+set NODE_OPTIONS=--openssl-legacy-provider
+npm start
+```
+
+A more proper fix is planned.
+
 ## WebAssembly
 
 The proof visualizer allows to run the CVC5 solver inside the browser. The WebAssembly binary used to run this in the browser is compiled via [emscripten](https://emscripten.org/).


### PR DESCRIPTION
This pr adds a workaround note to README.md regarding the `digital envelope routines` hash error that is generated by contemporary Node versions when running `npm start`. Discussions about the error are at https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported.